### PR TITLE
Custom field markers & overall improvements

### DIFF
--- a/bb-gmap.php
+++ b/bb-gmap.php
@@ -1,9 +1,9 @@
 <?php
 /**
  * Plugin Name: Beaver Builder - Google Maps
- * Plugin URI: http://www.thierry-pigot.fr
+ * Plugin URI: https://github.com/thierrypigot/beaver-builder-googlemaps
  * Description: Google Maps module for Beaver Builder.
- * Version: 1.4.3
+ * Version: 2.0.0
  * Author: Thierry Pigot
  * Author URI: http://www.thierry-pigot.fr
  */

--- a/tpbbgmap/includes/frontend.php
+++ b/tpbbgmap/includes/frontend.php
@@ -166,13 +166,20 @@ else{
 							
 							var m = $('#<?php echo esc_js( $mapsID ); ?>').gmap('addMarker', {
 								'position': results[0].geometry.location,
+								'title': marker.title,
 								'icon': icon,
 								'bounds': bounds
 							}).click(function() {
+								
 								if(marker.content)
 								{
-									$('#<?php echo esc_js( $mapsID ); ?>').gmap('openInfoWindow', { content : the_content( marker ) }, this);
+									marker.content = '<strong>' + marker.title + '</strong><br/>' + marker.content;
 								}
+								else{
+									marker.content = '<strong>' + marker.title + '</strong><br/>' + marker.address;
+								}
+								$('#<?php echo esc_js( $mapsID ); ?>').gmap('openInfoWindow', { content : the_content( marker ) }, this);
+								
 							})[0];
 							
 						} else {

--- a/tpbbgmap/includes/frontend.php
+++ b/tpbbgmap/includes/frontend.php
@@ -62,6 +62,7 @@ if ( stristr($settings->markers_type, 'automatic') ){
 					else{ //use stored coords
 						$markerdata['lat'] = $lat;
 						$markerdata['lng'] = $lng;
+						$markerdata['address'] = $address;
 					}
 						
 					$settings->markers[] = (object) $markerdata;

--- a/tpbbgmap/includes/frontend.php
+++ b/tpbbgmap/includes/frontend.php
@@ -176,7 +176,7 @@ else{
 							})[0];
 							
 						} else {
-							console.log('Geocode was not successful for the following reason: ' + status); //quieter error
+							console.log('Geocode was not successful with address "' + marker.address + '" for the following reason: ' + status); //quieter error
 						}
 					});
 						

--- a/tpbbgmap/includes/frontend.php
+++ b/tpbbgmap/includes/frontend.php
@@ -45,6 +45,7 @@ if ( stristr($settings->markers_type, 'automatic') ){
 							//Save for Javascript output
 							$markerdata['lat'] = $new_coords['lat'];
 							$markerdata['lng'] = $new_coords['lng'];
+							$markerdata['address'] = $new_coords['addr'];
 							
 							//Save to DB
 							if ( ! add_post_meta( $postid, $lat_field_name, $new_coords['lat'], true ) ) { 
@@ -53,6 +54,7 @@ if ( stristr($settings->markers_type, 'automatic') ){
 							if ( ! add_post_meta( $postid, $lng_field_name, $new_coords['lng'], true ) ) { 
    							update_post_meta( $postid, $lng_field_name, $new_coords['lng'] );
 							}
+							update_post_meta( $postid, $settings->address_cf, $new_coords['addr'] ); //update with formatted address
 							
 						}
 						
@@ -181,17 +183,21 @@ if( !isset( $atts['markers'] ) || ( empty(  $atts['markers'][0]->lat ) || empty(
 					} else {
 						var icon = '<?php echo esc_js( $bbgmap_map_defaut_icon ); ?>';
 					}
-													
-					var m = $('#<?php echo esc_js( $mapsID ); ?>').gmap('addMarker', {
-						'position': new google.maps.LatLng( marker.lat, marker.lng ),
-						'icon': icon,
-						'bounds': bounds
-					}).click(function() {
-						if(marker.content)
-						{
+					
+					if ( marker.lat && marker.lat.length > 0 && marker.lng && marker.lng.length > 0 ){
+						var m = $('#<?php echo esc_js( $mapsID ); ?>').gmap('addMarker', {
+							'position': new google.maps.LatLng( marker.lat, marker.lng ),
+							'icon': icon,
+							'bounds': bounds
+						}).click(function() {
+							
+							if (marker.content) marker.content = '<strong>' + marker.title + '</strong><br/>' + marker.content;
+							else marker.content = '<strong>' + marker.title + '</strong><br/>' + marker.address;
+
 							$('#<?php echo esc_js( $mapsID ); ?>').gmap('openInfoWindow', { content : the_content( marker ) }, this);
-						}
-					})[0];
+							
+						})[0];
+					}
 					
 				});
 

--- a/tpbbgmap/includes/frontend.php
+++ b/tpbbgmap/includes/frontend.php
@@ -19,7 +19,7 @@ if ( stristr($settings->markers_type, 'automatic') ){
 					
 					$markerdata = array(
 						'title' => get_the_title(),
-						'marker' => '<i class="' . $settings->marker_icon . '"></i>', //icon class
+						'marker' => $settings->marker_icon,
 						'content' => get_the_content(),
 					);
 					

--- a/tpbbgmap/includes/frontend.php
+++ b/tpbbgmap/includes/frontend.php
@@ -1,9 +1,11 @@
 <?php
 $mapsID = 'maps-'. uniqid();
 
-$query = FLBuilderLoop::query( $settings );
-
 if ( stristr($settings->markers_type, 'automatic') ){
+		
+	$settings->posts_per_page = -1; //We want all posts.
+	
+	$query = FLBuilderLoop::query( $settings );
 	
 	//Override the $settings->markers object values.
 	$settings->markers = array();

--- a/tpbbgmap/includes/frontend.php
+++ b/tpbbgmap/includes/frontend.php
@@ -176,7 +176,7 @@ else{
 							})[0];
 							
 						} else {
-							alert('Geocode was not successful for the following reason: ' + status);
+							console.log('Geocode was not successful for the following reason: ' + status); //quieter error
 						}
 					});
 						

--- a/tpbbgmap/includes/frontend.php
+++ b/tpbbgmap/includes/frontend.php
@@ -176,7 +176,7 @@ else{
 							})[0];
 							
 						} else {
-							console.log('Geocode was not successful with address "' + marker.address + '" for the following reason: ' + status); //quieter error
+							console.log('Geocode was not successful with post "' + marker.title + '" at address "' + marker.address + '" for the following reason: ' + status); //quieter error
 						}
 					});
 						

--- a/tpbbgmap/tpbbgmap.php
+++ b/tpbbgmap/tpbbgmap.php
@@ -20,9 +20,8 @@ class TPgMapModule extends FLBuilderModule {
         ));
 
 		$lang = explode('_', get_locale())[0]; //get_locale() returns format: en_US
-		$apikeytext = empty($this->settings->gmaps_api_key)? '' : '&amp;key=' . $this->settings->gmaps_api_key;
 		
-		$this->add_js( 'google-maps',       	'//maps.google.com/maps/api/js?language=' . $lang . '&amp;libraries=places' . $apikeytext, array('jquery'), null );
+		$this->add_js( 'google-maps',       	'//maps.google.com/maps/api/js?language=' . $lang . '&amp;libraries=places', array('jquery'), null );
 		$this->add_js( 'jquery-ui-map',     	$this->url .'assets/js/jquery.ui.map.min.js', array('jquery'), null, null );
 		$this->add_js( 'markerclusterer',		$this->url .'assets/js/markerclusterer.min.js', array('jquery','jquery-ui-map'), null, null );
 		$this->add_js( 'bb-gmaps-script',     	$this->url .'assets/js/script.js', array('markerclusterer'), null, null );

--- a/tpbbgmap/tpbbgmap.php
+++ b/tpbbgmap/tpbbgmap.php
@@ -94,12 +94,41 @@ FLBuilder::register_module('TPgMapModule', array(
 							'type'         => 'refresh'
 						)
 					),
+					'markers_type' => array(
+					    'type'          => 'select',
+					    'label'         => __( 'Map Marker Source', 'bbgmap' ),
+					    'default'       => 'manual',
+					    'options'       => array(
+					        'manual'      => __( 'Manually Specified Markers', 'bbgmap' ),
+					        'automatic'      => __( 'Automatic Markers from Custom Fields', 'bbgmap' )
+					    ),
+					    'toggle'        => array(
+					        'manual'      => array(
+					            'tabs'          => array( 'markersSection' )
+					        ),
+					        'automatic'      => array(
+											'fields'        => array( 'address_cf' ),
+											'tabs'          => array( 'markersAutoSection' )
+									),
+					    )
+					),
+					'address_cf'    => array(
+						'type'          => 'text',
+						'label'         => __('Address Custom Field', 'bbgmap'),
+						'placeholder'  	=> __( '_address', 'bbgmap' ),
+						//'description'		=> __( 'The name of the custom field that contains the address', 'bbgmap' ),
+						'help'					=> __( 'This field is used only when specifying Automatic Markers', 'bbgmap' ),
+					),
 				)
 			)
 		)
 	),
+	'markersAutoSection' => array(
+    'title'         => __( 'Automatic Markers', 'fl-builder' ),
+    'file'          => FL_BUILDER_DIR . 'includes/loop-settings.php',
+	),
 	'markersSection'       => array(
-		'title'         => __('Markers', 'bbgmap'),
+		'title'         => __('Manual Markers', 'bbgmap'),
 		'sections'      => array(
 			'general'       => array(
 				'title'         => '',

--- a/tpbbgmap/tpbbgmap.php
+++ b/tpbbgmap/tpbbgmap.php
@@ -52,6 +52,47 @@ class TPgMapModule extends FLBuilderModule {
 		}
 		return $field;
 	}
+	
+	// ------------------------------------------
+	// converts a string with a stret address
+	// into a couple of lat, long coordinates.
+	// https://www.codeofaninja.com/2014/06/google-maps-geocoding-example-php.html
+	// ------------------------------------------
+	public static function getLatLong($address){
+ 
+    // url encode the address
+    $address = urlencode($address);
+     
+    // google map geocode api url
+    $url = "http://maps.google.com/maps/api/geocode/json?address={$address}&key={$settings->gmaps_api_key}";
+ 
+    $resp = json_decode(file_get_contents($url), true);
+      
+    // response status will be 'OK', if able to geocode given address 
+    if($resp['status']=='OK'){
+ 
+        // get the important data
+        $lati = $resp['results'][0]['geometry']['location']['lat'];
+        $longi = $resp['results'][0]['geometry']['location']['lng'];
+        $formatted_address = $resp['results'][0]['formatted_address'];
+         
+        // verify if data is complete
+        if($lati && $longi){
+         
+            return array(
+							'lat' => $lati,
+							'lng' => $longi,
+							'addr' => $formatted_address,
+						);            
+                          
+        }
+				else return false;
+         
+    }
+		else return false;
+		
+	}
+	
 }
 
 /**


### PR DESCRIPTION
Large set of changes to:
- Provide UI for pulling map markers from post type custom fields
- Use an API key to avoid console warnings and increase limits
- Silence additional console warnings
- Specify language of map based on WordPress locale

Note: My French is very limited, so I haven’t included French translations, but I think I’ve set up all strings as translatable (sorry if I missed any!)